### PR TITLE
Fix Collapsed Topics and Columns course formats.  Requires V2.6.1.3 of Collapsed Topics and V2.6.1.1 of Columns.

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -662,6 +662,7 @@ class theme_elegance_format_weeks_renderer extends format_weeks_renderer {
     }
 }
 
+// Requires V2.6.1.3+ of Collapsed Topics format.
 if (file_exists("$CFG->dirroot/course/format/topcoll/renderer.php")) {
     include_once($CFG->dirroot . "/course/format/topcoll/renderer.php");
     class theme_elegance_format_topcoll_renderer extends format_topcoll_renderer {
@@ -671,7 +672,6 @@ if (file_exists("$CFG->dirroot/course/format/topcoll/renderer.php")) {
         }
 
         public function print_single_section_page($course, $sections, $mods, $modnames, $modnamesused, $displaysection) {
-            $this->courseformat = course_get_format($course); // Needed for collapsed topics settings retrieval.
             global $PAGE;
 
             $modinfo = get_fast_modinfo($course);
@@ -941,6 +941,7 @@ if (file_exists("$CFG->dirroot/course/format/noticebd/renderer.php")) {
     }
 }
 
+// Requires V2.6.1.1+ of Columns format.
 if (file_exists("$CFG->dirroot/course/format/columns/renderer.php")) {
     include_once($CFG->dirroot . "/course/format/columns/renderer.php");
     class theme_elegance_format_columns_renderer extends format_columns_renderer {
@@ -950,7 +951,6 @@ if (file_exists("$CFG->dirroot/course/format/columns/renderer.php")) {
         }
 
         public function print_single_section_page($course, $sections, $mods, $modnames, $modnamesused, $displaysection) {
-            $this->courseformat = course_get_format($course);
             global $PAGE;
 
             $modinfo = get_fast_modinfo($course);


### PR DESCRIPTION
Hi Julian,

Not the complete refactoring fix, but one that works and is simple.  Requires testing with versions of CT and Columns from:

https://github.com/gjb2048/moodle-format_topcoll/tree/MOODLE_26 - V2.6.1.3 - provisional.
https://github.com/gjb2048/moodle-format_columns/tree/MOODLE_26 - V2.6.1.1 - provisional.

If all is well, I'll release as fix works outside of Elegance theme.

Cheers,

Gareth
