### PR TITLE
load elegance sheet last

### DIFF
--- a/config.php
+++ b/config.php
@@ -51,7 +51,7 @@ if ((!empty($THEME->settings->tiles)) && ($THEME->settings->tiles == '1')) {
 	$tilessheet ='';
 }
 	
-$THEME->sheets = array('moodle', 'font-awesome.min', 'elegance', $categorysheet , $tilessheet, $loginsheet, ' nprogress');
+$THEME->sheets = array('moodle', 'font-awesome.min', $categorysheet , $tilessheet, $loginsheet, ' nprogress', 'elegance');
 
 $THEME->supportscssoptimisation = false;
 


### PR DESCRIPTION
prevents customcss settings from being overwritten when trying to overwrite category, tiles, or login css.
![screen shot 2014-02-27 at 10 51 03 am](https://f.cloud.github.com/assets/743499/2278671/9375a6b2-9f5a-11e3-96bc-2147d5747a71.png)
