### PR TITLE
fix 100% width breaking BS grid

### DIFF
--- a/style/elegance.css
+++ b/style/elegance.css
@@ -1794,10 +1794,6 @@ blockquote>.icon-quote-left{
 	position: relative;
 }
 
-.path-course.pagelayout-coursecategory #region-main{
-	width: 100%;
-}
-
 .box.courseboxes{
 	clear: both;
 	float: left;


### PR DESCRIPTION
Fix for issue #15. Forcing 100% width on #region-main broke the grid and pushed the block region below the content region.
