### PR TITLE
remove .sitelink background image

### DIFF
--- a/style/elegance.css
+++ b/style/elegance.css
@@ -776,7 +776,6 @@ border-bottom-color: #888;
 	font-size: .9em;
 }
 
-.sitelink,
 .homelink a {
 	float: left;
 	margin-right: 15px;


### PR DESCRIPTION
.sitelink contains an image element that outputs the moodlelogo, adding it as a background attribute duplicates the output.
![screen shot 2014-02-28 at 12 57 51 pm](https://f.cloud.github.com/assets/743499/2291129/e6b82da6-a034-11e3-9ae0-25a2a6160eff.png)
