### PR TITLE
fix .helplink floating into parent sibling row containing .homelink

### DIFF
--- a/style/elegance.css
+++ b/style/elegance.css
@@ -818,7 +818,6 @@ border-bottom-color: #888;
 
 #page-footer .helplink a{
 	position: relative;
-	float: left;
 	margin-top: -55px;
 	margin-left: 20px;
 	


### PR DESCRIPTION
.helplink doesn't position within its "row" container and covers up the parent sibling row containing .footnote and .sitelink

![screen shot 2014-03-11 at 2 14 31 pm](https://f.cloud.github.com/assets/743499/2382456/a206adbe-a8e4-11e3-92a8-8f764c7bcd96.png)

this fix removes the float and puts the link back in the center (because of text-align).  If you want it on the left you'll need to adjust the text-align attribute for the paragraph containing the link.
