### PR TITLE
add a sanity check to see if messaging is enabled before outputting menu item

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -148,6 +148,10 @@ class theme_elegance_core_renderer extends core_renderer {
         $addusermenu = true;
         $addlangmenu = true;
         $addmessagemenu = true;
+        
+        if (!$CFG->messaging) {
+            $addmessagemenu = false;
+        }
 
         if (!isloggedin() || isguestuser()) {
             $addmessagemenu = false;

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -156,7 +156,7 @@ class theme_elegance_core_renderer extends core_renderer {
             // Check whether or not the "popup" message output is enabled
             // This is after we check if messaging is enabled to possibly save a DB query
             $popup = $DB->get_record('message_processors', array('name'=>'popup'));
-            if(!$popup) {
+            if(!$popup->enabled) {
                 $addmessagemenu = false;
             }
         }

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -159,6 +159,7 @@ class theme_elegance_core_renderer extends core_renderer {
             if(!$popup) {
                 $addmessagemenu = false;
             }
+        }
 
         if (!isloggedin() || isguestuser()) {
             $addmessagemenu = false;

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -148,6 +148,18 @@ class theme_elegance_core_renderer extends core_renderer {
         $addusermenu = true;
         $addlangmenu = true;
         $addmessagemenu = true;
+        
+        // Check if messaging is enabled on the site
+        if (!$CFG->messaging) {
+            $addmessagemenu = false;
+        } else {
+            // Check whether or not the "popup" message output is enabled
+            // This is after we check if messaging is enabled to possibly save a DB query
+            $popup = $DB->get_record('message_processors', array('name'=>'popup'));
+            if(!$popup) {
+                $addmessagemenu = false;
+            }
+        }
 
         if (!isloggedin() || isguestuser()) {
             $addmessagemenu = false;

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -148,8 +148,7 @@ class theme_elegance_core_renderer extends core_renderer {
         $addusermenu = true;
         $addlangmenu = true;
         $addmessagemenu = true;
-        
-<<<<<<< HEAD
+
         // Check if messaging is enabled on the site
         if (!$CFG->messaging) {
             $addmessagemenu = false;
@@ -160,11 +159,6 @@ class theme_elegance_core_renderer extends core_renderer {
             if(!$popup) {
                 $addmessagemenu = false;
             }
-=======
-        if (!$CFG->messaging) {
-            $addmessagemenu = false;
->>>>>>> 101f9c5967e041cfc12f454de159ad24f58d9560
-        }
 
         if (!isloggedin() || isguestuser()) {
             $addmessagemenu = false;


### PR DESCRIPTION
If messaging is disabled we shouldn't output the messaging option on the custom menu.

TODO: check if popup notification or jabber are configured or not
