### PR TITLE
cleanup section footer

### DIFF
--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -663,11 +663,10 @@ class theme_elegance_format_topics_renderer extends format_topics_renderer {
 
         // Display section bottom navigation.
         $sectionbottomnav = '';
-        $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+        $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
         $sectionbottomnav .= $sectionnavlinks['previous'];
         $sectionbottomnav .= $sectionnavlinks['next'];
         // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-        $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
         $sectionbottomnav .= html_writer::end_tag('nav');
         echo $sectionbottomnav;
 

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -544,7 +544,7 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
             if ($canviewhidden || $sections[$back]->uservisible) {
                 $params = array('id' => 'previous_section');
                 if (!$sections[$back]->visible) {
-                    $params = array('class' => 'dimmed_text');
+                    $params = array('id' => 'previous_section', 'class' => 'dimmed_text');
                 }
                 $previouslink = $previousarrow;
                 $previouslink .= html_writer::start_tag('span', array('class' => 'text'));
@@ -564,7 +564,7 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
             if ($canviewhidden || $sections[$forward]->uservisible) {
                 $params = array('id' => 'next_section');
                 if (!$sections[$forward]->visible) {
-                    $params = array('class' => 'dimmed_text');
+                    $params = array('id' => 'next_section', 'class' => 'dimmed_text');
                 }
                 $nextlink = $nextarrow;
                 $nextlink .= html_writer::start_tag('span', array('class' => 'text'));

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -747,11 +747,10 @@ class theme_elegance_format_weeks_renderer extends format_weeks_renderer {
 
         // Display section bottom navigation.
         $sectionbottomnav = '';
-        $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+        $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
         $sectionbottomnav .= $sectionnavlinks['previous'];
         $sectionbottomnav .= $sectionnavlinks['next'];
         // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-        $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
         $sectionbottomnav .= html_writer::end_tag('nav');
         echo $sectionbottomnav;
 
@@ -838,11 +837,10 @@ if (file_exists("$CFG->dirroot/course/format/topcoll/renderer.php")) {
 
             // Display section bottom navigation.
             $sectionbottomnav = '';
-            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
             $sectionbottomnav .= $sectionnavlinks['previous'];
             $sectionbottomnav .= $sectionnavlinks['next'];
             // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-            $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
             $sectionbottomnav .= html_writer::end_tag('nav');
             echo $sectionbottomnav;
 
@@ -929,11 +927,10 @@ if (file_exists("$CFG->dirroot/course/format/grid/renderer.php")) {
 
             // Display section bottom navigation.
             $sectionbottomnav = '';
-            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
             $sectionbottomnav .= $sectionnavlinks['previous'];
             $sectionbottomnav .= $sectionnavlinks['next'];
             // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-            $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
             $sectionbottomnav .= html_writer::end_tag('nav');
             echo $sectionbottomnav;
 
@@ -1025,11 +1022,10 @@ if (file_exists("$CFG->dirroot/course/format/noticebd/renderer.php")) {
 
             // Display section bottom navigation.
             $sectionbottomnav = '';
-            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
             $sectionbottomnav .= $sectionnavlinks['previous'];
             $sectionbottomnav .= $sectionnavlinks['next'];
             // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-            $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
             $sectionbottomnav .= html_writer::end_tag('nav');
             echo $sectionbottomnav;
 
@@ -1117,11 +1113,10 @@ if (file_exists("$CFG->dirroot/course/format/columns/renderer.php")) {
 
             // Display section bottom navigation.
             $sectionbottomnav = '';
-            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer'));
+            $sectionbottomnav .= html_writer::start_tag('nav', array('id' => 'section_footer', 'class'=>'clearfix'));
             $sectionbottomnav .= $sectionnavlinks['previous'];
             $sectionbottomnav .= $sectionnavlinks['next'];
             // $sectionbottomnav .= html_writer::tag('div', $this->section_nav_selection($course, $sections, $displaysection), array('class' => 'mdl-align'));
-            $sectionbottomnav .= html_writer::empty_tag('br', array('style'=>'clear:both'));
             $sectionbottomnav .= html_writer::end_tag('nav');
             echo $sectionbottomnav;
 

--- a/renderers/core_renderer.php
+++ b/renderers/core_renderer.php
@@ -533,8 +533,8 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
         // FIXME: This is really evil and should by using the navigation API.
         $courseformat = course_get_format($course);
         $course = $courseformat->get_course();
-        $previousarrow= '<i class="fa fa-chevron-circle-left"></i>';
-        $nextarrow= '<i class="fa fa-chevron-circle-right"></i>';
+        $previousarrow= '<i class="nav_icon fa fa-chevron-circle-left"></i>';
+        $nextarrow= '<i class="nav_icon fa fa-chevron-circle-right"></i>';
         $canviewhidden = has_capability('moodle/course:viewhiddensections', context_course::instance($course->id))
             or !$course->hiddensections;
 
@@ -546,9 +546,7 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
                 if (!$sections[$back]->visible) {
                     $params = array('class' => 'dimmed_text');
                 }
-                $previouslink = html_writer::start_tag('div', array('class' => 'nav_icon'));
-                $previouslink .= $previousarrow;
-                $previouslink .= html_writer::end_tag('div');
+                $previouslink = $previousarrow;
                 $previouslink .= html_writer::start_tag('span', array('class' => 'text'));
                 $previouslink .= html_writer::start_tag('span', array('class' => 'nav_guide'));
                 $previouslink .= get_string('previoussection', 'theme_elegance');
@@ -568,9 +566,7 @@ function theme_elegance_get_nav_links($course, $sections, $sectionno) {
                 if (!$sections[$forward]->visible) {
                     $params = array('class' => 'dimmed_text');
                 }
-                $nextlink = html_writer::start_tag('div', array('class' => 'nav_icon'));
-                $nextlink .= $nextarrow;
-                $nextlink .= html_writer::end_tag('div');
+                $nextlink = $nextarrow;
                 $nextlink .= html_writer::start_tag('span', array('class' => 'text'));
                 $nextlink .= html_writer::start_tag('span', array('class' => 'nav_guide'));
                 $nextlink .= get_string('nextsection', 'theme_elegance');

--- a/style/elegance.css
+++ b/style/elegance.css
@@ -2020,11 +2020,13 @@ div.section-navigation.navigationtitle .mdl-right{
 	text-align:right;
 	font-weight: 300;
 	float: right;
+	width: 50%;
 }
 
 #previous_section {
 	font-weight: 300;
 	float: left;
+	width: 50%;
 }
 
 .nav_guide { 

--- a/style/elegance.css
+++ b/style/elegance.css
@@ -2019,7 +2019,6 @@ div.section-navigation.navigationtitle .mdl-right{
 #next_section {
 	text-align:right;
 	font-weight: 300;
-	display: inline-block;
 	float: right;
 }
 
@@ -2052,20 +2051,11 @@ letter-spacing:0.1em;
 	float: right;
 }
 
-#next_section .text{
-	width:74.05%;
-}
-
 #previous_section .nav_icon {
 	float:left;
 	margin-right:0.3em;
 	border-right:1px solid #eee;
 	font-size:2em;
-}
-
-#previous_section .text{
-	width:74.05%;
-	float:lef;
 }
 
 /* @end */

--- a/style/elegance.css
+++ b/style/elegance.css
@@ -2004,11 +2004,11 @@ div.section-navigation.navigationtitle .mdl-right{
 	border-bottom: 1px dotted #eee;
 }
 #section_footer {
-	padding:5px 0px;
+	padding:0px;
 	color: [[setting:themecolor]];
 	line-height:1.5; 
 	clear:both;
-	margin-top: -20px;
+	margin-top: -8px;
 }
 
 #section_footer a{


### PR DESCRIPTION
There are a few minor glitches with the #section_footer area.  The biggest is a missing ID output for hidden sections.  This pull request is a general cleanup.
before:
![screen shot 2014-04-09 at 8 59 44 am](https://cloud.githubusercontent.com/assets/743499/2651484/e350e734-bf8d-11e3-915e-1a2f8cda2b88.png)

after:
![screen shot 2014-04-09 at 10 18 48 am](https://cloud.githubusercontent.com/assets/743499/2651487/e8ff4cd4-bf8d-11e3-9275-00ed9653d8b2.png)
